### PR TITLE
Rebrand uniswap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ bower_components
 .lock-wscript
 
 # Compiled binary addons (https://nodejs.org/api/addons.html)
-build/Release
+build/
 
 # Dependency directories
 node_modules/

--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 
 Forked from [UniswapV2 subgraph](https://github.com/Uniswap/v2-subgraph).
 
-[Uniswap](https://uniswap.org/) is a decentralized protocol for automated token exchange on Ethereum.
-
-This subgraph dynamically tracks any pair created by the uniswap factory. It tracks of the current state of Uniswap contracts, and contains derived stats for things like historical data and USD prices.
+This subgraph dynamically tracks any pair created by the Common factory. It tracks of the current state of Common contracts, and contains derived stats for things like historical data and USD prices.
 
 - aggregated data across pairs and tokens,
 - data on individual pairs and tokens,
 - data on transactions
 - data on liquidity providers
-- historical data on Uniswap, pairs or tokens, aggregated by day
+- historical data on Common, pairs or tokens, aggregated by day
 
 ## Running Locally
 
@@ -18,13 +16,13 @@ Make sure to update package.json settings to point to your own graph account.
 
 ## Queries
 
-Below are a few ways to show how to query the uniswap-subgraph for data. The queries show most of the information that is queryable, but there are many other filtering options that can be used, just check out the [querying api](https://thegraph.com/docs/graphql-api). These queries can be used locally or in The Graph Explorer playground.
+Below are a few ways to show how to query the Common subgraph for data. The queries show most of the information that is queryable, but there are many other filtering options that can be used, just check out the [querying api](https://thegraph.com/docs/graphql-api). These queries can be used locally or in The Graph Explorer playground.
 
 ## Key Entity Overviews
 
-#### UniswapFactory
+#### Factory
 
-Contains data across all of Uniswap V2. This entity tracks important things like total liquidity (in ETH and USD, see below), all time volume, transaction count, number of pairs and more.
+Contains data across all of Common V2. This entity tracks important things like total liquidity (in ETH and USD, see below), all time volume, transaction count, number of pairs and more.
 
 #### Token
 
@@ -36,7 +34,7 @@ Contains data on a specific pair.
 
 #### Transaction
 
-Every transaction on Uniswap is stored. Each transaction contains an array of mints, burns, and swaps that occured within it.
+Every transaction on Common is stored. Each transaction contains an array of mints, burns, and swaps that occured within it.
 
 #### Mint, Burn, Swap
 
@@ -44,16 +42,16 @@ These contain specifc information about a transaction. Things like which pair tr
 
 ## Example Queries
 
-### Querying Aggregated Uniswap Data
+### Querying basic factory info
 
-This query fetches aggredated data from all uniswap pairs and tokens, to give a view into how much activity is happening within the whole protocol.
+This query fetches some basic info about tracked factories.
 
 ```graphql
 {
-  uniswapFactories(first: 1) {
+  factories {
+    id
     pairCount
-    totalVolumeUSD
-    totalLiquidityUSD
+    txCount
   }
 }
 ```

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,4 @@
-type UniswapFactory @entity {
+type Factory @entity {
   # factory address
   id: ID!
 
@@ -189,8 +189,8 @@ type Bundle @entity {
   ethPrice: BigDecimal! # price of ETH usd
 }
 
-# Data accumulated and condensed into day stats for all of Uniswap
-type UniswapDayData @entity {
+# Data accumulated and condensed into day stats for all of Common
+type DayData @entity {
   id: ID! # timestamp rounded to current day by dividing by 86400
   date: Int!
 

--- a/src/mappings/dayUpdates.ts
+++ b/src/mappings/dayUpdates.ts
@@ -1,32 +1,32 @@
 /* eslint-disable prefer-const */
 import { BigDecimal, BigInt, ethereum } from '@graphprotocol/graph-ts'
 
-import { Bundle, Pair, PairDayData, Token, TokenDayData, UniswapDayData, UniswapFactory } from '../types/schema'
+import { Bundle, Pair, PairDayData, Token, TokenDayData, DayData, Factory } from '../types/schema'
 import { PairHourData } from './../types/schema'
 import { FACTORY_ADDRESS, ONE_BI, ZERO_BD, ZERO_BI } from './helpers'
 
-export function updateUniswapDayData(event: ethereum.Event): UniswapDayData {
-  let uniswap = UniswapFactory.load(FACTORY_ADDRESS)!
+export function updateDayData(event: ethereum.Event): DayData {
+  let factory = Factory.load(FACTORY_ADDRESS)!
   let timestamp = event.block.timestamp.toI32()
   let dayID = timestamp / 86400
   let dayStartTimestamp = dayID * 86400
-  let uniswapDayData = UniswapDayData.load(dayID.toString())
-  if (uniswapDayData === null) {
-    uniswapDayData = new UniswapDayData(dayID.toString())
-    uniswapDayData.date = dayStartTimestamp
-    uniswapDayData.dailyVolumeUSD = ZERO_BD
-    uniswapDayData.dailyVolumeETH = ZERO_BD
-    uniswapDayData.totalVolumeUSD = ZERO_BD
-    uniswapDayData.totalVolumeETH = ZERO_BD
-    uniswapDayData.dailyVolumeUntracked = ZERO_BD
+  let dayData = DayData.load(dayID.toString())
+  if (dayData === null) {
+    dayData = new DayData(dayID.toString())
+    dayData.date = dayStartTimestamp
+    dayData.dailyVolumeUSD = ZERO_BD
+    dayData.dailyVolumeETH = ZERO_BD
+    dayData.totalVolumeUSD = ZERO_BD
+    dayData.totalVolumeETH = ZERO_BD
+    dayData.dailyVolumeUntracked = ZERO_BD
   }
 
-  uniswapDayData.totalLiquidityUSD = uniswap.totalLiquidityUSD
-  uniswapDayData.totalLiquidityETH = uniswap.totalLiquidityETH
-  uniswapDayData.txCount = uniswap.txCount
-  uniswapDayData.save()
+  dayData.totalLiquidityUSD = factory.totalLiquidityUSD
+  dayData.totalLiquidityETH = factory.totalLiquidityETH
+  dayData.txCount = factory.txCount
+  dayData.save()
 
-  return uniswapDayData as UniswapDayData
+  return dayData as DayData
 }
 
 export function updatePairDayData(event: ethereum.Event): PairDayData {

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -2,7 +2,7 @@
 import { log } from '@graphprotocol/graph-ts'
 
 import { PairCreated } from '../types/Factory/Factory'
-import { Bundle, Pair, Token, UniswapFactory } from '../types/schema'
+import { Bundle, Pair, Token, Factory } from '../types/schema'
 import { Pair as PairTemplate } from '../types/templates'
 import {
   FACTORY_ADDRESS,
@@ -16,9 +16,9 @@ import {
 
 export function handleNewPair(event: PairCreated): void {
   // load factory (create if first exchange)
-  let factory = UniswapFactory.load(FACTORY_ADDRESS)
+  let factory = Factory.load(FACTORY_ADDRESS)
   if (factory === null) {
-    factory = new UniswapFactory(FACTORY_ADDRESS)
+    factory = new Factory(FACTORY_ADDRESS)
     factory.pairCount = 0
     factory.totalVolumeETH = ZERO_BD
     factory.totalLiquidityETH = ZERO_BD


### PR DESCRIPTION
## Description

Rebrand repo so that `uniswap` is not used. Change graphql, then mappings accordingly, and README. For example there's no `UniswapFactory` entity, but `Factory` entity instead.